### PR TITLE
fix(build): adiciona spring-boot-maven-plugin para corrigir manifesto…

### DIFF
--- a/src/main/java/com/example/overclockAPI/repository/UsuarioRepository.java
+++ b/src/main/java/com/example/overclockAPI/repository/UsuarioRepository.java
@@ -3,4 +3,4 @@ package com.example.overclockAPI.repository;
 import com.example.overclockAPI.entitys.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UsuarioRepository extends JpaRepository<Usuario, Long>{}
+public interface UsuarioRepository extends JpaRepository<Usuario,Long>{}


### PR DESCRIPTION
… do JAR Este commit adiciona o spring-boot-maven-plugin ao pom.xml para garantir que o arquivo JAR gerado contenha as entradas corretas no manifesto (Main-Class e Start-Class).

>>
>> Anteriormente, o manifesto não continha a entrada Main-Class, o que impedia a execução do JAR com o erro no main manifest attribute. Com a adição do plugin, o Maven agora gera um JAR executável compatível com Spring Boot.
>>
>> Alterações:
>> - Adicionado spring-boot-maven-plugin na seção <build> do pom.xml