### PR TITLE
feat(security): adiciona configuração CORS para desenvolvimento local

### DIFF
--- a/src/main/java/com/example/overclockAPI/infra/cors/CorsConfig.java
+++ b/src/main/java/com/example/overclockAPI/infra/cors/CorsConfig.java
@@ -1,0 +1,21 @@
+package com.example.overclockAPI.infra.cors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins:http://localhost:3000}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(org.springframework.web.servlet.config.annotation.CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        allowedOrigins)
+                .allowedMethods("GET", "POST", "DELETE")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,5 +12,7 @@ spring.jpa.show-sql=true
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 
+cors.allowed-origins=http://localhost:3000
+
 # Chave do JWT
 api.security.token.security=${JWT_SECRET}


### PR DESCRIPTION
- Implementa CorsConfig para gerenciar origens permitidas
- Adiciona configuração de origens permitidas no application.properties
- Permite acesso da origem http://localhost:3000
- Habilita métodos HTTP necessários (GET, POST, PUT, DELETE)
- Prepara estrutura para suporte futuro a múltiplas origens

ref: #36