### PR TITLE
fix(cors): configura CORS para permitir todas as origens

### DIFF
--- a/src/main/java/com/example/overclockAPI/infra/cors/CorsConfig.java
+++ b/src/main/java/com/example/overclockAPI/infra/cors/CorsConfig.java
@@ -1,23 +1,33 @@
 package com.example.overclockAPI.infra.cors;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${cors.allowed-origins:http://localhost:3000}")
-    private String[] allowedOrigins;
+   @Bean
+    public CorsFilter corsFilter(){
+       org.springframework.web.cors.UrlBasedCorsConfigurationSource source = new org.springframework.web.cors.UrlBasedCorsConfigurationSource();
+       CorsConfiguration config = new CorsConfiguration();
 
-    @Override
-    public void addCorsMappings(org.springframework.web.servlet.config.annotation.CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins(
-                        allowedOrigins)
-                .allowedMethods("GET", "POST", "DELETE")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
-    }
+       config.addAllowedOriginPattern("*");
+
+       config.setAllowCredentials(true);
+
+       config.addAllowedHeader("*");
+
+       config.addExposedHeader("Authorization");
+
+       config.addAllowedMethod("*");
+
+       config.setMaxAge(3600L);
+
+       source.registerCorsConfiguration("/**", config);
+       return new CorsFilter(source);
+   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,12 @@ spring.jpa.show-sql=true
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 
-cors.allowed-origins=http://localhost:3000
+spring.web.cors.allowed-origins=*
+spring.web.cors.allowed-methods=*
+spring.web.cors.allowed-headers=*
+spring.web.cors.exposed-headers=*
+spring.web.cors.allow-credentials=true
+spring.web.cors.max-age=3600
 
 # Chave do JWT
 api.security.token.security=${JWT_SECRET}


### PR DESCRIPTION
# Correção da Configuração CORS para Permitir Todas as Origens

## Descrição
Implementação de uma nova configuração CORS mais permissiva para resolver problemas de integração com diferentes ambientes de frontend, especialmente durante o desenvolvimento e deploy.

## Mudanças
- Substituição da implementação `WebMvcConfigurer` por `CorsFilter` para maior controle
- Configuração para permitir todas as origens usando `addAllowedOriginPattern("*")`
- Adição de headers de exposição e autorização
- Atualização das propriedades CORS no `application.properties`

## Detalhes Técnicos
- Implementação via `CorsFilter` Bean
- Configuração global através do `UrlBasedCorsConfigurationSource`
- Cache de preflight definido para 1 hora (3600 segundos)
- Suporte a credenciais habilitado
- Exposição do header de Authorization

## Propriedades Configuradas
- `spring.web.cors.allowed-origins=*`
- `spring.web.cors.allowed-methods=*`
- `spring.web.cors.allowed-headers=*`
- `spring.web.cors.exposed-headers=*`
- `spring.web.cors.allow-credentials=true`
- `spring.web.cors.max-age=3600`

## Testes Realizados
- [x] Teste de login através do frontend local
- [x] Verificação de headers CORS nas requisições preflight
- [x] Validação de credenciais em requisições cross-origin
- [x] Teste com frontend em diferentes origens

## Observações de Segurança
⚠️ Esta configuração é mais permissiva e deve ser revisada antes do deploy em produção. Considerar restringir:
- Origens permitidas
- Métodos HTTP específicos
- Headers necessários

ref: #36 