### PR TITLE
feat(infra): configura publicação de pacotes no github

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Packages
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Build with Maven
+        run: mvn package
+
+      - name: Run tests
+        run: mvn test
+
+      - name: Publish to GitHub Packages
+        run: mvn deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,14 @@
 		</dependency>
 	</dependencies>
 
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>Overclock Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/matheusfesantos/BackEnd-Overclock</url>
+		</repository>
+	</distributionManagement>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
# Configuração de Publicação no GitHub Packages

## Descrição
Implementa a configuração necessária para publicação automatizada de pacotes Maven no GitHub Packages, permitindo melhor gerenciamento e distribuição dos artefatos do projeto.

## Alterações Realizadas
- Configuração do `distributionManagement` no `pom.xml`
- Limpeza e otimização do arquivo `maven-wrapper.properties`
- Preparação da infraestrutura para integração com GitHub Packages

## Impacto
- Permite publicação automatizada de pacotes no GitHub
- Facilita o gerenciamento de dependências
- Melhora o processo de distribuição do projeto

## Testes
- [ ] Verificar configuração do Maven
- [ ] Testar processo de publicação
- [ ] Validar acesso ao repositório

## Referências
ref: #53

## Notas Adicionais
Após o merge, será necessário configurar as credenciais do GitHub para acesso ao repositório de pacotes.